### PR TITLE
fix - Short the server name if it's too long - leaderboard servers button

### DIFF
--- a/views/leaderboard.handlebars
+++ b/views/leaderboard.handlebars
@@ -38,9 +38,9 @@
                             data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                             Server leaderboards
                         </button>
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton" style="max-width: 320px;">
                             {{#each islenoxbotnp}}
-                            <a class="dropdown-item lb-dropdown-item" href="/leaderboards/server/{{id}}">{{name}}</a>
+                            <a class="dropdown-item lb-dropdown-item lb-textcap" href="/leaderboards/server/{{id}}">{{name}}</a>
                             {{/each}}
                         </div>
                         {{else}}


### PR DESCRIPTION
**Please describe the changes this pull request makes and why it should be merged:**
- Fixed the dropdown button in leaderboards page (Short the server name if it's too long)

**Status:**
- [x] Code changes have been tested
- [x] Code changes work without errors

**Content of the pull request:**  
- [x] This pull request changes the Website
  - [ ] This pull request includes breaking changes for the Dashboard
  - [ ] This pull request includes new page(s) for the website
- [ ] This pull request **only** includes non-code changes, like changes to templates, README, etc.
